### PR TITLE
feat: add refreshQuery

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
 		"@typescript-eslint/no-unused-vars": ["off", { argsIgnorePattern: "^_" }],
 		"no-mixed-spaces-and-tabs": "off",
 		"no-case-declarations": "off",
+		"jest/no-test-callback": "off",
 	},
 };

--- a/rx-query/__tests__/key.test.ts
+++ b/rx-query/__tests__/key.test.ts
@@ -1,0 +1,21 @@
+import { createQueryKey } from '..';
+
+it('uses the key as key', () => {
+	const key = createQueryKey('mykey', undefined);
+	expect(key).toBe('mykey');
+});
+
+it('adds the string param to the key', () => {
+	const key = createQueryKey('my', 'key');
+	expect(key).toBe('my-key');
+});
+
+it('adds the number param to the key', () => {
+	const key = createQueryKey('mykey', 7);
+	expect(key).toBe('mykey-7');
+});
+
+it('adds a serialized object param to the key', () => {
+	const key = createQueryKey('mykey', { id: 4 });
+	expect(key).toBe('mykey-{"id":4}');
+});

--- a/rx-query/__tests__/refresh.test.ts
+++ b/rx-query/__tests__/refresh.test.ts
@@ -1,0 +1,13 @@
+import { refreshQuery, revalidate, queryCache } from '..';
+
+it('sends emits a refresh event', (done) => {
+	revalidate.subscribe({
+		next: (value) => {
+			expect(value.trigger).toBe('manual');
+			expect(value.key).toBe('key-param');
+			done();
+		},
+	});
+
+	refreshQuery('key', 'param');
+});

--- a/rx-query/__tests_types__/query.test-d.ts
+++ b/rx-query/__tests_types__/query.test-d.ts
@@ -1,6 +1,6 @@
 import { expectType } from 'tsd';
 import { Observable, of } from 'rxjs';
-import { query, QueryOutput } from '.';
+import { query, QueryOutput } from '..';
 
 /**
  * Default

--- a/rx-query/index.ts
+++ b/rx-query/index.ts
@@ -1,5 +1,7 @@
 export { query } from './query';
 export { queryCache, revalidate, resetQueryCache } from './cache';
+export { createQueryKey } from './key';
+export { refreshQuery } from './refresh';
 export { prefetch } from './prefetch';
 export { mutateSuccess, mutateError, mutateOptimistic } from './mutate';
 export { DEFAULT_QUERY_CONFIG } from './config';

--- a/rx-query/key.ts
+++ b/rx-query/key.ts
@@ -1,0 +1,16 @@
+/**
+ * Creates a query key based on the key and the params
+ */
+export function createQueryKey(key: string, params: unknown): string {
+	if (params !== undefined && params !== null) {
+		return (
+			key +
+			'-' +
+			(['string', 'number'].includes(typeof params)
+				? params
+				: JSON.stringify(params))
+		);
+	}
+
+	return key;
+}

--- a/rx-query/refresh.ts
+++ b/rx-query/refresh.ts
@@ -1,0 +1,14 @@
+import { revalidate } from './cache';
+import { QueryConfig } from './types';
+import { createQueryKey } from './key';
+
+/**
+ *  Trigger a refresh of the query
+ */
+export function refreshQuery(key: string, paramInput?: unknown): void {
+	revalidate.next({
+		key: createQueryKey(key, paramInput),
+		trigger: 'manual',
+		config: (undefined as unknown) as Required<QueryConfig>,
+	});
+}

--- a/src/examples/pagination.component.ts
+++ b/src/examples/pagination.component.ts
@@ -44,7 +44,7 @@ import { FormBuilder } from '@angular/forms';
 				[disabled]="orders.data?.hasMoreData !== true"
 				class="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
 			>
-				Next {{ orders.data?.hasMoreData }}
+				Next
 			</button>
 			<div *ngIf="orders.status === 'refreshing'">{{ orders.status }}</div>
 			<div>


### PR DESCRIPTION
Allows to manually refresh a query with `refreshQuery`.
Usage:

```ts
refreshQuery('some-key');
refreshQuery('some-key', {id:3});
```