### PR TITLE
Add Dev Tools

### DIFF
--- a/rx-query/query.ts
+++ b/rx-query/query.ts
@@ -171,7 +171,10 @@ export function query(
 					// exclude state changes that are unimportant to the consumer
 					!['query-unsubscribe', 'group-unsubscribe'].includes(v.trigger),
 			),
-			map((v) => v.groupState.result as QueryOutput),
+			map((v) => {
+			  console.count('result')
+			  return v.groupState.result as QueryOutput
+      }),
 			distinctUntilChanged(),
 			patchDataWithPreviousData(queryConfig.keepPreviousData),
 			finalize(() => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -49,7 +49,7 @@ export class AppComponent implements OnInit, OnDestroy {
 		() => this.rickAndMortyService.getCharacters().pipe(pluck('results')),
 		{
 			refetchOnWindowFocus: true,
-			staleTime: 10_000,
+			// staleTime: 10_000,
 		},
 	);
 
@@ -62,7 +62,7 @@ export class AppComponent implements OnInit, OnDestroy {
 			(characterId: number) =>
 				this.rickAndMortyService.getCharacter(characterId),
 			{
-				staleTime: 50000,
+				// staleTime: 50000,
 			},
 		);
 
@@ -72,7 +72,7 @@ export class AppComponent implements OnInit, OnDestroy {
 			(characterId: number) =>
 				this.rickAndMortyService.getCharacter(characterId),
 			{
-				staleTime: 50000,
+				// staleTime: 50000,
 			},
 		);
 	}

--- a/src/app/cache-devtool.component.ts
+++ b/src/app/cache-devtool.component.ts
@@ -100,6 +100,7 @@ export class RxQueryDevToolComponent {
 	cache$ = queryCache.pipe(
 		map((c) => {
 			return Object.entries(c).map(([key, value]) => {
+			  console.log('devtool', value.groupState.result.status, value.groupState.key, value.trigger)
 				return {
 					key,
 					data: value.groupState.result.data,


### PR DESCRIPTION
Hey,

I am trying to show the number of queries which are fetching right now.

<img width="1680" alt="Screenshot 2021-03-05 at 07 44 02" src="https://user-images.githubusercontent.com/35801656/110078863-a314b680-7d88-11eb-8f5c-020713a0c83c.png">

However there is something I don't understand, so I provided this commit with some console.logs.
- npm start
- clear the console
- Enable network throttling Slow 3G
- Hover over Rick Sanchez

The network request is made and this gets logged immediately

<img width="1680" alt="Screenshot 2021-03-05 at 08 04 01" src="https://user-images.githubusercontent.com/35801656/110079459-6eedc580-7d89-11eb-88b9-8babf9bdaafc.png">

After 1s the network request comes back and this gets logged
<img width="1680" alt="Screenshot 2021-03-05 at 08 04 03" src="https://user-images.githubusercontent.com/35801656/110079580-92b10b80-7d89-11eb-9c02-f715380b458d.png">

This makes it impossible for me to show the currently fetching requests in the dev tools, because after the loading state is correctly emitted (between queryCache: 4 and queryCache: 5), the cache$ in the dev tool immediately emits again with the loading state missing (between queryCache: 5 and queryCache: 6).

Should prefetch() unsubscribe only after a successful response and not immediately? Could this be the reason for my issue? (I am still struggling to understand the code base)