### PR TITLE
fix: test and avoid jest deprecation message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: install
-        run: npm install
+        run: npm install --legacy-peer-deps
       - name: build
         run: npm run dist:build
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 15]
+        node-version: [12, 14, 16]
 
     steps:
       - uses: actions/checkout@v1
@@ -29,13 +29,13 @@ jobs:
       - name: test
         run: npm run test
       - name: Release
-        if: github.repository == 'timdeschryver/rx-query' && github.ref == 'refs/heads/master' && matrix.node-version == 15
+        if: github.repository == 'timdeschryver/rx-query' && github.ref == 'refs/heads/master' && matrix.node-version == 16
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
       - name: deploy storybook to GH pages
-        if: github.repository == 'timdeschryver/rx-query' && github.ref == 'refs/heads/master' && matrix.node-version == 15
+        if: github.repository == 'timdeschryver/rx-query' && github.ref == 'refs/heads/master' && matrix.node-version == 16
         run: npm run deploy-storybook -- --ci
         env:
           GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}

--- a/rx-query/__tests__/query.test.ts
+++ b/rx-query/__tests__/query.test.ts
@@ -428,7 +428,7 @@ it('invokes query on focus', async () => {
 
 	setTimeout(() => {
 		fireEvent.focus(window);
-	}, 10);
+	}, 100);
 
 	for await (const value of eachValueFrom(
 		query('test', () => of(i++), {

--- a/src/setup-test.ts
+++ b/src/setup-test.ts
@@ -1,4 +1,4 @@
-import 'jest-preset-angular';
+import 'jest-preset-angular/setup-jest';
 import '@testing-library/jest-dom';
 import { server } from './mocks/server';
 


### PR DESCRIPTION
I forked the project and tried to run the tests, however it doesn't seem to finish:

```
 RUNS  rx-query/__tests__/query.test.ts

Test Suites: 1 skipped, 4 passed, 4 of 6 total
Tests:       1 skipped, 9 passed, 10 total
Snapshots:   0 total
Time:        413 s
```

After some debugging I found the test that was causing this issue. After increasing the timeout for the event the test passes.

Also, some change to avoid the following deprecation message:
```
ts-jest[root] (WARN) Import setup jest file via `import 'jest-preset-angular';` is deprecated and will be removed in v9.0.0. Please switch to `import 'jest-preset-angular/setup-jest';`
```